### PR TITLE
DPRO-946: Catch the possibles Not JSON responses

### DIFF
--- a/src/main/java/org/plos/crepo/util/HttpResponseUtil.java
+++ b/src/main/java/org/plos/crepo/util/HttpResponseUtil.java
@@ -2,6 +2,7 @@ package org.plos.crepo.util;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -26,15 +27,22 @@ public class HttpResponseUtil {
   public static String getErrorMessage(HttpResponse response) {
     HttpEntity entity = response.getEntity();
     String responseMessage;
+    String errorMessage;
     try {
       responseMessage = EntityUtils.toString(entity, CharEncoding.UTF_8);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    Gson gson = new Gson();
-    JsonElement responseElement = gson.fromJson(responseMessage, JsonElement.class);
-    JsonElement message = responseElement.getAsJsonObject().get("message");
-    return (message == null) ? "No error message" : message.getAsString();
+
+    try {
+      Gson gson = new Gson();
+      JsonElement responseElement = gson.fromJson(responseMessage, JsonElement.class);
+      JsonElement message = responseElement.getAsJsonObject().get("message");
+      errorMessage = (message == null)? "No error message":message.getAsString();
+    } catch (JsonSyntaxException e) { // Catch the possibles NOT JSON responses.
+      errorMessage = "There was an error trying to obtain the JSON response error: " + response.getStatusLine();
+    }
+    return errorMessage;
   }
 
 }


### PR DESCRIPTION
Modify the HttpResponseUtil to catch the possibles errors with HTML responses (HTTP 405 Error). If the response is not a JSON a exception with the message "There was an error trying to obtain the JSON response error: HTTP Error" is throw.
